### PR TITLE
Adds react-router and md5 as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,17 +19,19 @@
   "author": "Cory House",
   "license": "MIT",
   "dependencies": {
+    "immutable": "~3.7.6",
+    "md5": "2.1.0",
     "object-assign": "4.0.1",
     "react": "0.14.7",
     "react-dom": "0.14.7",
+    "react-immutable-proptypes": "~1.7.0",
     "react-redux": "4.4.0",
+    "react-router": "2.4.1",
     "redux": "3.3.1",
     "redux-form": "~4.2.0",
-    "redux-thunk": "~2.0.1",
     "redux-logger": "~2.6.1",
     "redux-promise": "~0.5.1",
-    "immutable": "~3.7.6",
-    "react-immutable-proptypes": "~1.7.0"
+    "redux-thunk": "~2.0.1"
   },
   "devDependencies": {
     "babel-cli": "6.5.1",


### PR DESCRIPTION
Dependencies for react-router and md5 were missing in package.json causing the build to fail
